### PR TITLE
Remove unneeded resume() call

### DIFF
--- a/src/StreamingClient.php
+++ b/src/StreamingClient.php
@@ -67,7 +67,6 @@ class StreamingClient extends EventEmitter implements Client
         });
 
         $stream->on('close', array($this, 'close'));
-        $stream->resume();
 
         $this->stream = $stream;
         $this->parser = $parser;


### PR DESCRIPTION
Fixed `PHP Warning:  fread(): 294 is not a valid stream resource in .../react/stream/src/Stream.php on line 127`

Call Stream::resume in https://github.com/reactphp/stream/blob/master/src/Stream.php#L40

Perhaps this problem, Read Stream Listener is not successfully deleted when you close the connection, warning came out after a while.
Code to strictly reproduce is difficult, but it was caused by my production.

This pull request, because the first time that for me, there may be a problem with the manners, but please forgive me. and i'm afraid my expressions may be rude or hard to read, because I'm not so good at English.