### PR TITLE
Fix redis:// being rejected and username:password passing invalid auth to Redis

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -98,7 +98,8 @@ class Factory
         }
 
         $parts = parse_url($target);
-        if ($parts === false || !isset($parts['host']) || $parts['scheme'] !== 'tcp') {
+        $validSchemes = array('redis', 'tcp');
+        if ($parts === false || !isset($parts['host']) || !in_array($parts['scheme'], $validSchemes)) {
             throw new InvalidArgumentException('Given URL can not be parsed');
         }
 
@@ -110,16 +111,14 @@ class Factory
             $parts['host'] = '127.0.0.1';
         }
 
-        $auth = null;
-        if (isset($parts['user'])) {
-            $auth = $parts['user'];
-        }
+        // username:password@ (Redis doesn't support usernames)
         if (isset($parts['pass'])) {
-            $auth .= ':' . $parts['pass'];
-        }
-        if ($auth !== null) {
-            $parts['auth'] = $auth;
-        }
+			$parts['auth'] = $parts['pass'];
+		}
+		// password@
+		else if (isset($parts['user'])) {
+			$parts['auth'] = $parts['user'];
+		}
 
         if (isset($parts['path']) && $parts['path'] !== '') {
             // skip first slash

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -111,14 +111,13 @@ class Factory
             $parts['host'] = '127.0.0.1';
         }
 
-        // username:password@ (Redis doesn't support usernames)
         if (isset($parts['pass'])) {
-			$parts['auth'] = $parts['pass'];
-		}
-		// password@
-		else if (isset($parts['user'])) {
-			$parts['auth'] = $parts['user'];
-		}
+            // username:password@ (Redis doesn't support usernames)
+            $parts['auth'] = $parts['pass'];
+        } elseif (isset($parts['user'])) {
+            // password@
+            $parts['auth'] = $parts['user'];
+        }
 
         if (isset($parts['path']) && $parts['path'] !== '') {
             // skip first slash

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -64,10 +64,19 @@ class FactoryTest extends TestCase
     public function testWillWriteAuthCommandIfTargetContainsUserInfo()
     {
         $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->getMock();
-        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$11\r\nhello:world\r\n");
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$11\r\nworld\r\n");
 
         $this->connector->expects($this->once())->method('create')->willReturn(Promise\resolve($stream));
         $this->factory->createClient('tcp://hello:world@127.0.0.1');
+    }
+    
+    public function testWillWriteAuthCommandIfTargetContainsPasswordAsUser()
+    {
+        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->getMock();
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$11\r\nworld\r\n");
+
+        $this->connector->expects($this->once())->method('create')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('tcp://world@127.0.0.1');
     }
 
     public function testWillRejectIfConnectorRejects()

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -64,7 +64,7 @@ class FactoryTest extends TestCase
     public function testWillWriteAuthCommandIfTargetContainsUserInfo()
     {
         $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->getMock();
-        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$11\r\nworld\r\n");
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nworld\r\n");
 
         $this->connector->expects($this->once())->method('create')->willReturn(Promise\resolve($stream));
         $this->factory->createClient('tcp://hello:world@127.0.0.1');
@@ -73,7 +73,7 @@ class FactoryTest extends TestCase
     public function testWillWriteAuthCommandIfTargetContainsPasswordAsUser()
     {
         $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->getMock();
-        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$11\r\nworld\r\n");
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nworld\r\n");
 
         $this->connector->expects($this->once())->method('create')->willReturn(Promise\resolve($stream));
         $this->factory->createClient('tcp://world@127.0.0.1');


### PR DESCRIPTION
As discussed in #40, Sending auth `username:password` to a Redis server doesn't make any sense right now.  Some services such as Redis Cloud automatically setup the urls in the form of `bogus_username:password@server` and only the password part should be sent on to Redis.  Also `redis://` is a valid schema prefix.
