### PR TITLE
Factory accepts Connector from Socket and deprecate legacy SocketClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,28 @@ $factory = new Factory($loop);
 ```
 
 If you need custom DNS, proxy or TLS settings, you can explicitly pass a
-custom instance of the [`ConnectorInterface`](https://github.com/reactphp/socket-client#connectorinterface):
+custom instance of the [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
+$connector = new \React\Socket\Connector($loop, array(
+    'dns' => '127.0.0.1',
+    'tcp' => array(
+        'bindto' => '192.168.10.1:0'
+    ),
+    'tls' => array(
+        'verify_peer' => false,
+        'verify_peer_name' => false
+    )
+));
+
 $factory = new Factory($loop, $connector);
 ```
+
+> Legacy notice: As of `v1.2.0`, the optional connector should implement the new
+  `React\Socket\ConnectorInterface`. For BC reasons it also accepts the
+  legacy `React\SocketClient\ConnectorInterface`.
+  This legacy API will be removed in a future `v2.0.0` version, so it's highly
+  recommended to upgrade to the above API.
 
 #### createClient()
 

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,10 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/promise": "^2.0 || ^1.1",
-        "react/socket-client": "^0.7",
         "react/event-loop": "0.3.*|0.4.*",
+        "react/promise": "^2.0 || ^1.1",
+        "react/socket": "^0.7",
+        "react/socket-client": "^0.7",
         "clue/redis-protocol": "0.3.*",
         "evenement/evenement": "~1.0|~2.0"
     },

--- a/src/ConnectionUpcaster.php
+++ b/src/ConnectionUpcaster.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Clue\React\Redis;
+
+use Evenement\EventEmitter;
+use React\Socket\ConnectionInterface;
+use React\Stream\DuplexStreamInterface;
+use React\Stream\WritableStreamInterface;
+use React\Stream\Util;
+
+/**
+ * Adapter to upcast a legacy SocketClient-Connector result to a new Socket-ConnectionInterface
+ *
+ * @internal
+ */
+class ConnectionUpcaster extends EventEmitter implements ConnectionInterface
+{
+    private $stream;
+
+    public function __construct(DuplexStreamInterface $stream)
+    {
+        $this->stream = $stream;
+
+        Util::forwardEvents($stream, $this, array('data', 'end', 'close', 'error', 'drain'));
+        $this->stream->on('close', array($this, 'close'));
+    }
+
+    public function isReadable()
+    {
+        return $this->stream->isReadable();
+    }
+
+    public function isWritable()
+    {
+        return $this->isWritable();
+    }
+
+    public function pause()
+    {
+        $this->stream->pause();
+    }
+
+    public function resume()
+    {
+        $this->stream->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        $this->stream->pipe($dest, $options);
+    }
+
+    public function write($data)
+    {
+        return $this->stream->write($data);
+    }
+
+    public function end($data = null)
+    {
+        return $this->stream->end($data);
+    }
+
+    public function close()
+    {
+        $this->stream->close();
+        $this->removeAllListeners();
+    }
+
+    public function getRemoteAddress()
+    {
+        return null;
+    }
+
+    public function getLocalAddress()
+    {
+        return null;
+    }
+}

--- a/src/ConnectorUpcaster.php
+++ b/src/ConnectorUpcaster.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Clue\React\Redis;
+
+use React\Socket\ConnectorInterface;
+use React\SocketClient\ConnectorInterface as LegacyConnectorInterface;
+use React\Stream\DuplexStreamInterface;
+
+/**
+ * Adapter to upcast a legacy SocketClient:v0.7/v0.6 Connector to a new Socket:v0.8 Connector
+ *
+ * @internal
+ */
+class ConnectorUpcaster implements ConnectorInterface
+{
+    private $legacy;
+
+    public function __construct(LegacyConnectorInterface $connector)
+    {
+        $this->legacy = $connector;
+    }
+
+    public function connect($uri)
+    {
+        return $this->legacy->connect($uri)->then(function (DuplexStreamInterface $stream) {
+            return new ConnectionUpcaster($stream);
+        });
+    }
+}

--- a/src/StreamingClient.php
+++ b/src/StreamingClient.php
@@ -3,10 +3,8 @@
 namespace Clue\React\Redis;
 
 use Evenement\EventEmitter;
-use React\Stream\Stream;
 use Clue\Redis\Protocol\Parser\ParserInterface;
 use Clue\Redis\Protocol\Parser\ParserException;
-use Clue\Redis\Protocol\Model\ErrorReplyException;
 use Clue\Redis\Protocol\Serializer\SerializerInterface;
 use Clue\Redis\Protocol\Factory as ProtocolFactory;
 use UnderflowException;
@@ -17,6 +15,7 @@ use Clue\Redis\Protocol\Model\ErrorReply;
 use Clue\Redis\Protocol\Model\ModelInterface;
 use Clue\Redis\Protocol\Model\MultiBulkReply;
 use Clue\Redis\Protocol\Model\StatusReply;
+use React\Stream\DuplexStreamInterface;
 
 /**
  * @internal
@@ -34,7 +33,7 @@ class StreamingClient extends EventEmitter implements Client
     private $psubscribed = 0;
     private $monitoring = false;
 
-    public function __construct(Stream $stream, ParserInterface $parser = null, SerializerInterface $serializer = null)
+    public function __construct(DuplexStreamInterface $stream, ParserInterface $parser = null, SerializerInterface $serializer = null)
     {
         if ($parser === null || $serializer === null) {
             $factory = new ProtocolFactory();

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -5,6 +5,7 @@ use Clue\React\Redis\Factory;
 use Clue\React\Redis\StreamingClient;
 use React\Promise\Deferred;
 use Clue\React\Block;
+use React\SocketClient\Connector;
 
 class FunctionalTest extends TestCase
 {
@@ -37,6 +38,20 @@ class FunctionalTest extends TestCase
         $this->assertFalse($client->isBusy());
 
         return $client;
+    }
+
+    public function testPingClientWithLegacyConnector()
+    {
+        $this->client->close();
+        $this->factory = new Factory($this->loop, new Connector($this->loop));
+        $this->client = $this->createClient(getenv('REDIS_URI'));
+
+        $promise = $this->client->ping();
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableOnce('PONG'));
+
+        $this->client->end();
+        $this->waitFor($this->client);
     }
 
     public function testMgetIsNotInterpretedAsSubMessage()


### PR DESCRIPTION
If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
proxy servers etc.), you can explicitly pass a custom instance of the
[`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):

```php
$connector = new \React\Socket\Connector($loop, array(
    'dns' => '127.0.0.1',
    'tcp' => array(
        'bindto' => '192.168.10.1:0'
    ),
    'tls' => array(
        'verify_peer' => false,
        'verify_peer_name' => false
    )
));

$factory = new Factory($loop, $connector);
```

Builds on top of #58
Refs #50
Heavily inspired by https://github.com/clue/php-buzz-react/pull/76