### PR TITLE
Support redis[s]:// URI scheme and deprecate legacy URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $factory = new Factory($loop, $connector);
 #### createClient()
 
 The `createClient($redisUri = null)` method can be used to create a new [`Client`](#client).
-It helps with establishing a plain TCP/IP connection to Redis
+It helps with establishing a plain TCP/IP or secure TLS connection to Redis
 and optionally authenticating (AUTH) and selecting the right database (SELECT).
 
 ```php
@@ -121,7 +121,9 @@ $factory->createClient('redis://localhost:6379')->then(
 );
 ```
 
-The `$redisUri` can be given in the form `[redis://][:auth@]host[:port][/db]`.
+The `$redisUri` can be given in the
+[standard](https://www.iana.org/assignments/uri-schemes/prov/redis) form
+`[redis[s]://][:auth@]host[:port][/db]`.
 You can omit the URI scheme and port if you're connecting to the default port 6379:
 
 ```php
@@ -148,6 +150,13 @@ You can optionally include a path that will be used to select (SELECT command) t
 
 ```php
 $factory->createClient('redis://localhost/2');
+```
+
+You can use the [standard](https://www.iana.org/assignments/uri-schemes/prov/rediss)
+`rediss://` URI scheme if you're using a secure TLS proxy in front of Redis:
+
+```php
+$factory->createClient('rediss://redis.example.com:6340');
 ```
 
 [Deprecated] You can omit the complete URI if you want to connect to the default

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ authentication mechanism does not employ a username, so you can pass the
 password "secret" as part of the URI like this:
 
 ```php
+// both forms are equivalent
 $factory->createClient('redis://ignored:secret@localhost');
+$factory->createClient('redis://localhost?password=secret');
 ```
 
 > Legacy notice: The `redis://` scheme is defined and preferred as of `v1.2.0`.
@@ -149,7 +151,9 @@ $factory->createClient('redis://ignored:secret@localhost');
 You can optionally include a path that will be used to select (SELECT command) the right database:
 
 ```php
+// both forms are equivalent
 $factory->createClient('redis://localhost/2');
+$factory->createClient('redis://localhost?db=2');
 ```
 
 You can use the [standard](https://www.iana.org/assignments/uri-schemes/prov/rediss)

--- a/README.md
+++ b/README.md
@@ -134,12 +134,13 @@ $factory->createClient('redis://localhost:6379');
 
 Redis supports password-based authentication (`AUTH` command). Note that Redis'
 authentication mechanism does not employ a username, so you can pass the
-password "secret" as part of the URI like this:
+password `h@llo` URL-encoded (percent-encoded) as part of the URI like this:
 
 ```php
-// both forms are equivalent
-$factory->createClient('redis://ignored:secret@localhost');
-$factory->createClient('redis://localhost?password=secret');
+// all forms are equivalent
+$factory->createClient('redis://:h%40llo@localhost');
+$factory->createClient('redis://ignored:h%40llo@localhost');
+$factory->createClient('redis://localhost?password=h%40llo');
 ```
 
 > Legacy notice: The `redis://` scheme is defined and preferred as of `v1.2.0`.

--- a/README.md
+++ b/README.md
@@ -121,12 +121,6 @@ $factory->createClient('localhost:6379')->then(
 );
 ```
 
-You can omit the complete URI if you want to connect to the default address `localhost:6379`:
-
-```php
-$factory->createClient();
-```
-
 You can omit the port if you're connecting to the default port 6379:
 
 ```php
@@ -143,6 +137,15 @@ You can optionally include a path that will be used to select (SELECT command) t
 
 ```php
 $factory->createClient('localhost/2');
+```
+
+[Deprecated] You can omit the complete URI if you want to connect to the default
+address `localhost:6379`. This legacy API will be removed in a future
+`v2.0.0` version, so it's highly recommended to upgrade to the above API.
+
+```php
+// deprecated
+$factory->createClient();
 ```
 
 ### Client

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ It helps with establishing a plain TCP/IP connection to Redis
 and optionally authenticating (AUTH) and selecting the right database (SELECT).
 
 ```php
-$factory->createClient('localhost:6379')->then(
+$factory->createClient('redis://localhost:6379')->then(
     function (Client $client) {
         // client connected (and authenticated)
     },
@@ -121,26 +121,37 @@ $factory->createClient('localhost:6379')->then(
 );
 ```
 
-You can omit the port if you're connecting to the default port 6379:
+The `$redisUri` can be given in the form `[redis://][:auth@]host[:port][/db]`.
+You can omit the URI scheme and port if you're connecting to the default port 6379:
 
 ```php
+// both are equivalent due to defaults being applied
 $factory->createClient('localhost');
+$factory->createClient('redis://localhost:6379');
 ```
 
-You can optionally include a password that will be used to authenticate (AUTH command) the client:
+Redis supports password-based authentication (`AUTH` command). Note that Redis'
+authentication mechanism does not employ a username, so you can pass the
+password "secret" as part of the URI like this:
 
 ```php
-$factory->createClient('auth@localhost');
+$factory->createClient('redis://ignored:secret@localhost');
 ```
+
+> Legacy notice: The `redis://` scheme is defined and preferred as of `v1.2.0`.
+  For BC reasons, the `Factory` defaults to the `tcp://` scheme in which case
+  the authentication details would include the otherwise unused username.
+  This legacy API will be removed in a future `v2.0.0` version, so it's highly
+  recommended to upgrade to the above API.
 
 You can optionally include a path that will be used to select (SELECT command) the right database:
 
 ```php
-$factory->createClient('localhost/2');
+$factory->createClient('redis://localhost/2');
 ```
 
 [Deprecated] You can omit the complete URI if you want to connect to the default
-address `localhost:6379`. This legacy API will be removed in a future
+address `redis://localhost:6379`. This legacy API will be removed in a future
 `v2.0.0` version, so it's highly recommended to upgrade to the above API.
 
 ```php

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -109,7 +109,7 @@ class Factory
         }
 
         $parts = parse_url($target);
-        if ($parts === false || !isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('tcp', 'redis'))) {
+        if ($parts === false || !isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('tcp', 'redis', 'rediss'))) {
             throw new InvalidArgumentException('Given URL can not be parsed');
         }
 
@@ -135,6 +135,10 @@ class Factory
         if (isset($parts['path']) && $parts['path'] !== '') {
             // skip first slash
             $parts['db'] = substr($parts['path'], 1);
+        }
+
+        if ($parts['scheme'] === 'rediss') {
+            $parts['host'] = 'tls://' . $parts['host'];
         }
 
         unset($parts['scheme'], $parts['user'], $parts['pass'], $parts['path']);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -141,6 +141,19 @@ class Factory
             $parts['host'] = 'tls://' . $parts['host'];
         }
 
+        if (isset($parts['query'])) {
+            $args = array();
+            parse_str($parts['query'], $args);
+
+            if (isset($args['password'])) {
+                $parts['auth'] = $args['password'];
+            }
+
+            if (isset($args['db'])) {
+                $parts['db'] = $args['db'];
+            }
+        }
+
         unset($parts['scheme'], $parts['user'], $parts['pass'], $parts['path']);
 
         return $parts;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -109,7 +109,7 @@ class Factory
         }
 
         $parts = parse_url($target);
-        if ($parts === false || !isset($parts['host']) || $parts['scheme'] !== 'tcp') {
+        if ($parts === false || !isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('tcp', 'redis'))) {
             throw new InvalidArgumentException('Given URL can not be parsed');
         }
 
@@ -122,11 +122,11 @@ class Factory
         }
 
         $auth = null;
-        if (isset($parts['user'])) {
+        if (isset($parts['user']) && $parts['scheme'] === 'tcp') {
             $auth = $parts['user'];
         }
         if (isset($parts['pass'])) {
-            $auth .= ':' . $parts['pass'];
+            $auth .= ($parts['scheme'] === 'tcp' ? ':' : '') . $parts['pass'];
         }
         if ($auth !== null) {
             $parts['auth'] = $auth;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -44,7 +44,9 @@ class Factory
     /**
      * create redis client connected to address of given redis instance
      *
-     * @param string|null $target
+     * @param string|null $target Redis server URI to connect to. Not passing
+     *     this parameter is deprecated and only supported for BC reasons and
+     *     will be removed in future versions.
      * @return \React\Promise\PromiseInterface resolves with Client or rejects with \Exception
      */
     public function createClient($target = null)

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -123,10 +123,10 @@ class Factory
 
         $auth = null;
         if (isset($parts['user']) && $parts['scheme'] === 'tcp') {
-            $auth = $parts['user'];
+            $auth = rawurldecode($parts['user']);
         }
         if (isset($parts['pass'])) {
-            $auth .= ($parts['scheme'] === 'tcp' ? ':' : '') . $parts['pass'];
+            $auth .= ($parts['scheme'] === 'tcp' ? ':' : '') . rawurldecode($parts['pass']);
         }
         if ($auth !== null) {
             $parts['auth'] = $auth;

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -86,6 +86,15 @@ class FactoryTest extends TestCase
         $this->factory->createClient('redis://hello:world@example.com');
     }
 
+    public function testWillWriteAuthCommandIfRedisUriContainsEncodedUserInfo()
+    {
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nh@llo\r\n");
+
+        $this->connector->expects($this->once())->method('connect')->with('example.com:6379')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('redis://:h%40llo@example.com');
+    }
+
     public function testWillWriteAuthCommandIfTargetContainsPasswordQueryParameter()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
@@ -93,6 +102,15 @@ class FactoryTest extends TestCase
 
         $this->connector->expects($this->once())->method('connect')->with('example.com:6379')->willReturn(Promise\resolve($stream));
         $this->factory->createClient('redis://example.com?password=secret');
+    }
+
+    public function testWillWriteAuthCommandIfTargetContainsEncodedPasswordQueryParameter()
+    {
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nh@llo\r\n");
+
+        $this->connector->expects($this->once())->method('connect')->with('example.com:6379')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('redis://example.com?password=h%40llo');
     }
 
     public function testWillWriteAuthCommandIfRedissUriContainsUserInfo()

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -68,6 +68,15 @@ class FactoryTest extends TestCase
         $this->factory->createClient('redis://127.0.0.1/demo');
     }
 
+    public function testWillWriteSelectCommandIfTargetContainsDbQueryParameter()
+    {
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $stream->expects($this->once())->method('write')->with("*2\r\n$6\r\nselect\r\n$1\r\n4\r\n");
+
+        $this->connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('redis://127.0.0.1?db=4');
+    }
+
     public function testWillWriteAuthCommandIfRedisUriContainsUserInfo()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
@@ -75,6 +84,15 @@ class FactoryTest extends TestCase
 
         $this->connector->expects($this->once())->method('connect')->with('example.com:6379')->willReturn(Promise\resolve($stream));
         $this->factory->createClient('redis://hello:world@example.com');
+    }
+
+    public function testWillWriteAuthCommandIfTargetContainsPasswordQueryParameter()
+    {
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$6\r\nsecret\r\n");
+
+        $this->connector->expects($this->once())->method('connect')->with('example.com:6379')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('redis://example.com?password=secret');
     }
 
     public function testWillWriteAuthCommandIfRedissUriContainsUserInfo()

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -73,8 +73,17 @@ class FactoryTest extends TestCase
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nworld\r\n");
 
-        $this->connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($stream));
-        $this->factory->createClient('redis://hello:world@127.0.0.1');
+        $this->connector->expects($this->once())->method('connect')->with('example.com:6379')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('redis://hello:world@example.com');
+    }
+
+    public function testWillWriteAuthCommandIfRedissUriContainsUserInfo()
+    {
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nworld\r\n");
+
+        $this->connector->expects($this->once())->method('connect')->with('tls://example.com:6379')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('rediss://hello:world@example.com');
     }
 
     public function testWillWriteAuthCommandIfTcpUriContainsUserInfo()

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -65,10 +65,19 @@ class FactoryTest extends TestCase
         $stream->expects($this->once())->method('write')->with("*2\r\n$6\r\nselect\r\n$4\r\ndemo\r\n");
 
         $this->connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($stream));
-        $this->factory->createClient('tcp://127.0.0.1/demo');
+        $this->factory->createClient('redis://127.0.0.1/demo');
     }
 
-    public function testWillWriteAuthCommandIfTargetContainsUserInfo()
+    public function testWillWriteAuthCommandIfRedisUriContainsUserInfo()
+    {
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nworld\r\n");
+
+        $this->connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('redis://hello:world@127.0.0.1');
+    }
+
+    public function testWillWriteAuthCommandIfTcpUriContainsUserInfo()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$11\r\nhello:world\r\n");


### PR DESCRIPTION
This project now supports standard `redis://` and `rediss://` URI schemes:

```php
$factory->createClient('redis://:secret@localhost:6379/4');
$factory->createClient('redis://localhost:6379?password=secret&db=4');
```

See also https://www.iana.org/assignments/uri-schemes/prov/redis and https://www.iana.org/assignments/uri-schemes/prov/rediss
Resolves / closes #40 
Supersedes / closes #42