### PR TITLE
Remove uneeded data event for performance and consistency reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,6 @@ Incoming events and errors will be forwarded to registered event handler callbac
 
 ```php
 // global events:
-$client->on('data', function (MessageInterface $message) {
-    // process an incoming message (raw message object)
-});
 $client->on('close', function () {
     // the connection to Redis just closed
 });

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,12 +4,10 @@ namespace Clue\React\Redis;
 
 use Evenement\EventEmitterInterface;
 use React\Promise\PromiseInterface;
-use Clue\Redis\Protocol\Model\ModelInterface;
 
 /**
  * Simple interface for executing redis commands
  *
- * @event data(ModelInterface $messageModel)
  * @event error(Exception $error)
  * @event close()
  *

--- a/src/StreamingClient.php
+++ b/src/StreamingClient.php
@@ -124,8 +124,6 @@ class StreamingClient extends EventEmitter implements Client
 
     public function handleMessage(ModelInterface $message)
     {
-        $this->emit('data', array($message));
-
         if ($this->monitoring && $this->isMonitorMessage($message)) {
             $this->emit('monitor', array($message));
             return;

--- a/tests/StreamingClientTest.php
+++ b/tests/StreamingClientTest.php
@@ -56,21 +56,8 @@ class StreamingClientTest extends TestCase
         $this->stream->emit('data', array('message'));
     }
 
-    public function testReceiveMessageEmitsEvent()
-    {
-        $this->client->on('data', $this->expectCallableOnce());
-
-        $this->parser->expects($this->once())->method('pushIncoming')->with($this->equalTo('message'))->will($this->returnValue(array(new IntegerReply(2))));
-        $this->stream->emit('data', array('message'));
-    }
-
     public function testReceiveThrowMessageEmitsErrorEvent()
     {
-        $this->client->on('data', $this->expectCallableOnce());
-        $this->client->on('data', function() {
-            throw new UnderflowException();
-        });
-
         $this->client->on('error', $this->expectCallableOnce());
 
         $this->parser->expects($this->once())->method('pushIncoming')->with($this->equalTo('message'))->will($this->returnValue(array(new IntegerReply(2))));


### PR DESCRIPTION
The `data` event is underdocumented for the most part and has attracted some low quality code in the past. It used to be more of a poor attempt to make the `Client` behave like a `ReadableStreamInterface` which doesn't make much sense for the rest of the interface anyway.

As such, this PR simply removes the `data` event, which makes the interface more consistent. Removing unneeded events also has a noticeable effect on performance.