### PR TITLE
Remove underdocumented isBusy() method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -34,13 +34,6 @@ interface Client extends EventEmitterInterface
     public function __call($name, $args);
 
     /**
-     * Checks if the client is busy, i.e. still has any requests pending
-     *
-     * @return boolean
-     */
-    public function isBusy();
-
-    /**
      * end connection once all pending requests have been replied to
      *
      * @uses self::close() once all replies have been received

--- a/src/StreamingClient.php
+++ b/src/StreamingClient.php
@@ -143,21 +143,16 @@ class StreamingClient extends EventEmitter implements Client
             $request->resolve($message->getValueNative());
         }
 
-        if ($this->ending && !$this->isBusy()) {
+        if ($this->ending && !$this->requests) {
             $this->close();
         }
-    }
-
-    public function isBusy()
-    {
-        return !!$this->requests;
     }
 
     public function end()
     {
         $this->ending = true;
 
-        if (!$this->isBusy()) {
+        if (!$this->requests) {
             $this->close();
         }
     }

--- a/tests/StreamingClientTest.php
+++ b/tests/StreamingClientTest.php
@@ -85,7 +85,6 @@ class StreamingClientTest extends TestCase
         $promise = $this->client->monitor();
 
         $this->expectPromiseReject($promise);
-        $this->assertFalse($this->client->isBusy());
     }
 
 
@@ -103,28 +102,21 @@ class StreamingClientTest extends TestCase
     public function testClosingClientRejectsAllRemainingRequests()
     {
         $promise = $this->client->ping();
-        $this->assertTrue($this->client->isBusy());
-
         $this->client->close();
 
         $this->expectPromiseReject($promise);
-        $this->assertFalse($this->client->isBusy());
     }
 
     public function testClosedClientRejectsAllNewRequests()
     {
         $this->client->close();
-
         $promise = $this->client->ping();
 
         $this->expectPromiseReject($promise);
-        $this->assertFalse($this->client->isBusy());
     }
 
     public function testEndingNonBusyClosesClient()
     {
-        $this->assertFalse($this->client->isBusy());
-
         $this->client->on('close', $this->expectCallableOnce());
         $this->client->end();
     }


### PR DESCRIPTION
The `isBusy()` method is underdocumented (not even documented in the README) and has attracted some low quality code in the past.

This PR simply removes this method, which reduces surface of the interface and makes the remaining interface more consistent.