### PR TITLE
Update Socket dependency to support hosts file on all platforms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "^2.0 || ^1.1",
-        "react/socket": "^1.0 || ^0.8 || ^0.7"
+        "react/socket": "^1.0 || ^0.8.3"
     },
     "autoload": {
         "psr-4": { "Clue\\React\\Redis\\": "src/" }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -107,10 +107,6 @@ class Factory
             $parts['port'] = 6379;
         }
 
-        if ($parts['host'] === 'localhost') {
-            $parts['host'] = '127.0.0.1';
-        }
-
         if (isset($parts['pass'])) {
             $parts['auth'] = rawurldecode($parts['pass']);
         }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -27,9 +27,9 @@ class FactoryTest extends TestCase
         $this->factory->createClient('redis.example.com');
     }
 
-    public function testWillConnectToLocalIpWhenTargetIsLocalhost()
+    public function testWillConnectToLocalhost()
     {
-        $this->connector->expects($this->once())->method('connect')->with('127.0.0.1:1337')->willReturn(Promise\reject(new \RuntimeException()));
+        $this->connector->expects($this->once())->method('connect')->with('localhost:1337')->willReturn(Promise\reject(new \RuntimeException()));
         $this->factory->createClient('localhost:1337');
     }
 


### PR DESCRIPTION
The underlying `Connector` now honors the hosts file on all platforms by default. This means that you can now send requests to `localhost` etc..

Resolves / closes #32
Refs reactphp/socket#112
Originally from https://github.com/reactphp/http-client/pull/108