### PR TITLE
added tcp to the list of accepted schemes

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -106,7 +106,7 @@ class Factory
         }
 
         $parts = parse_url($target);
-        if ($parts === false || !isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('redis', 'rediss'))) {
+        if ($parts === false || !isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('redis', 'tcp', 'rediss'))) {
             throw new InvalidArgumentException('Given URL can not be parsed');
         }
 


### PR DESCRIPTION
Currently tcp scheme is not accepted. It is accepted with predis and others. For compatibility with other libraries, I suggest you include it as well.